### PR TITLE
Check for `unmark` before building benchmarks

### DIFF
--- a/build
+++ b/build
@@ -1,2 +1,7 @@
 #!/bin/sh
-topkg build -- --with-unix true --with-lwt true --benchmarks true --examples true
+benchmarks=true
+if [ ! `ocamlfind ocamldep -package unmark` ] ; then
+    echo "Skipping benchmarks"
+    benchmarks=false
+fi
+topkg build -- --with-unix true --with-lwt true --benchmarks ${benchmarks} --examples true


### PR DESCRIPTION
Resolves #20:
> 1. Add a check for the unmark package and build with --benchmarks false if not present