### PR TITLE
Fix typo in `event` documentation

### DIFF
--- a/src-lwt/notty_lwt.mli
+++ b/src-lwt/notty_lwt.mli
@@ -57,7 +57,7 @@ module Term : sig
       {ul
       {- [#Unescape.event], an {{!Notty.Unescape.event}event} from the input
          fd; or}
-      {- [`Resize (int * int)] whenever the terminal size changes.}}
+      {- [`Resize (cols, rows)] whenever the terminal size changes.}}
 
       {b Note} This stream is unique; for the same [t], [events t] always
       returns the same stream. *)

--- a/src-unix/notty_unix.mli
+++ b/src-unix/notty_unix.mli
@@ -86,7 +86,7 @@ module Term : sig
       {ul
       {- [#Unescape.event], an {{!Notty.Unescape.event}[event]} from the input fd;}
       {- [`End] if the input fd is closed, or the terminal was released; or}
-      {- [`Resize (cols * rows)] giving the current size of the output tty, if a
+      {- [`Resize (cols, rows)] giving the current size of the output tty, if a
          [SIGWINCH] was delivered before or during this call to [event].}}
 
       {b Note} [event] is buffered. Calls can either block or immediately


### PR DESCRIPTION
Changed to use pattern syntax consistently instead of type expression syntax.