### PR TITLE
Add build files for Github workflows.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: Main workflow
+
+on:
+  - pull_request
+  - push
+  - workflow_dispatch
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            ocaml-compiler: 4.14.0
+          - os: macos-latest
+            ocaml-compiler: 4.13.1
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install -t --deps-only .
+          
+      - run: opam exec -- dune build


### PR DESCRIPTION
Add a build workflow for Github based off of the example in [ocaml/setup-ocaml](https://github.com/ocaml/setup-ocaml).

I get an error message about a missing C header when running for Windows, see the [logs](https://github.com/yilinwei/notty/runs/8209514046?check_suite_focus=true), though I'm not sure whether it's expected or not.