### PR TITLE
feature: add "dim" style

### DIFF
--- a/src/notty.ml
+++ b/src/notty.ml
@@ -210,6 +210,7 @@ module A = struct
 
   let bold      = 1
   and italic    = 2
+  and dim       = 3
   and underline = 4
   and blink     = 8
   and reverse   = 16

--- a/src/notty.mli
+++ b/src/notty.mli
@@ -139,6 +139,7 @@ module A : sig
 
   val bold      : style
   val italic    : style
+  val dim       : style
   val underline : style
   val blink     : style
   val reverse   : style


### PR DESCRIPTION
We are experimenting with using notty in Dune at the moment. We needed a "dim" style which is typically represented as ANSI code `3`. We have this change in our own fork, so I am upstreaming the patch here.