### PR TITLE
add support of dim/faint

### DIFF
--- a/examples/colors.ml
+++ b/examples/colors.ml
@@ -27,15 +27,18 @@ let colors = A.[
 ]
 
 let styles = A.[
-  "empty"      , empty
-; "bold"       , st bold
-; "italic"     , st italic
-; "underline"  , st underline
-; "blink"      , st blink
-; "reverse"    , st reverse
-; "bold/italic", st bold ++ st italic
-; "rev/underln", st underline ++ st reverse
-; "bold/rev"   , st reverse ++ st bold
+  "empty"       , empty
+; "bold"        , st bold
+; "faint"       , st faint
+; "italic"      , st italic
+; "underline"   , st underline
+; "blink"       , st blink
+; "reverse"     , st reverse
+; "bold/italic" , st bold ++ st italic
+; "faint/italic", st faint ++ st italic
+; "rev/underln" , st underline ++ st reverse
+; "bold/rev"    , st reverse ++ st bold
+; "faint/rev"   , st reverse ++ st faint
 ]
 
 let image w =

--- a/src/notty.ml
+++ b/src/notty.ml
@@ -209,10 +209,12 @@ module A = struct
   and b x = x land 0xff
 
   let bold      = 1
-  and italic    = 2
-  and underline = 4
-  and blink     = 8
-  and reverse   = 16
+  and dim       = 2
+  and faint     = 2
+  and italic    = 4
+  and underline = 8
+  and blink     = 16
+  and reverse   = 32
 
   let empty = { fg = 0; bg = 0; st = 0 }
 
@@ -510,7 +512,7 @@ module Cap = struct
 
   let ((<|), (<.), (<!)) = Buffer.(add_string, add_char, add_decimal)
 
-  let sts = [ ";1"; ";3"; ";4"; ";5"; ";7" ]
+  let sts = [ ";1"; ";2"; ";3"; ";4"; ";5"; ";7" ]
 
   let sgr { A.fg; bg; st } buf =
     buf <| "\x1b[0";

--- a/src/notty.mli
+++ b/src/notty.mli
@@ -138,6 +138,8 @@ module A : sig
   (** Additional text properties. *)
 
   val bold      : style
+  val dim       : style
+  val faint     : style
   val italic    : style
   val underline : style
   val blink     : style


### PR DESCRIPTION
This is the correct implementation of #44. I also updated `examples/colors.ml` so that one can easily check the results.

This is the screenshot with this PR on the terminal emulator `kitty`.
![image](https://github.com/pqwy/notty/assets/1471328/d4ba2c7a-eac5-4f97-b2bf-067d84910bf6)